### PR TITLE
Add basics of pythonosc backend.

### DIFF
--- a/live/set.py
+++ b/live/set.py
@@ -25,7 +25,7 @@ except ImportError:
     # Python 2 support
     import urllib
 
-class Set (LoggingObject):
+class Set(LoggingObject):
     """ Set represents an entire running Live set. It communicates via a
     live.Query object to the Live instance, which must be running LiveOSC
     as an active control surface.

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,29 @@ setup(
     author_email = 'dan-pylive@erase.net',
     url = 'https://github.com/ideoforms/pylive',
     packages = ['live'],
+
+    # TODO for me on windows 10 at least, in a fresh python 3.8 venv, i need
+    # to pre install cython with: pip install cython
+    # or else the `pip install ./` will fail even though 'cython' is also
+    # in `install_requires`. test that `./setup.py install` behaves the same
+    # way! + try to find workaround so cython gets installed first if not
+    # fixable (or either way, really)
+
+    # Since it seems it is not possible to specify "default" values for
+    # the keys in "extras_require" (without hacks that would prevent this 
+    # `setup.py` from being used to release wheels), I think the best option is
+    # to always install pyliblo, even if it is not functional because there is
+    # not a working installed liblo library. Then, we just need to make sure we
+    # can detect either whether we have pythonosc, or whether the installed
+    # pyliblo+liblo is actually working.
+
+    # It does however seem that there is a fairly high bar for pyliblo's build
+    # succeeding... I think I was only able to achieve this on MSYS2 on Windows,
+    # with a bit of installation of dependencies required.
     install_requires = ['cython', 'pyliblo >= 0.9.1'],
+    extras_require={
+        'pythonosc': ['python-osc']
+    },
     keywords = ('sound', 'music', 'ableton', 'osc'),
     classifiers = [
         'Topic :: Multimedia :: Sound/Audio',


### PR DESCRIPTION
liblo/pythonosc selectable with env var PYLIVE_BACKEND. Change setup.py to ultimately enable pythonosc support install like: pip install pylive[pythonosc]. Closes #13.