### PR TITLE
Add `track.color_index` + get `tempdir` path on Windows

### DIFF
--- a/live/classes/set.py
+++ b/live/classes/set.py
@@ -214,9 +214,7 @@ class Set:
         self.groups = []
 
         import json
-        tempdir = tempfile.gettempdir()
-        tmp = tempdir + "\abletonosc-song-structure.json" if platform.system() == "Windows" else "/tmp/abletonosc-song-structure.json"
-        with open(tmp, "r") as fd:
+        with open(os.path.join(tempfile.gettempdir(), "abletonosc-song-structure.json"), "r") as fd:
             data = json.load(fd)
             tracks = data["tracks"]
             for track_data in tracks:

--- a/live/classes/set.py
+++ b/live/classes/set.py
@@ -3,6 +3,8 @@
 import os
 import math
 import glob
+import platform
+import tempfile
 import time
 import pickle
 import logging
@@ -212,7 +214,9 @@ class Set:
         self.groups = []
 
         import json
-        with open("/tmp/abletonosc-song-structure.json", "r") as fd:
+        tempdir = tempfile.gettempdir()
+        tmp = tempdir + "\abletonosc-song-structure.json" if platform.system() == "Windows" else "/tmp/abletonosc-song-structure.json"
+        with open(tmp, "r") as fd:
             data = json.load(fd)
             tracks = data["tracks"]
             for track_data in tracks:

--- a/live/classes/track.py
+++ b/live/classes/track.py
@@ -159,6 +159,9 @@ class Track:
     fired_slot_index = property(fget=make_getter("track", "fired_slot_index"),
                                 fset=make_setter("track", "fired_slot_index"),
                                 doc="Fired slot index")
+    color_index = property(fget=make_getter("track", "color_index"),
+                           fset=make_setter("track", "color_index"),
+                           doc="Color index (0.69)")
 
     def get_send(self, send_index: int):
         return self.live.query("/live/track/get/send", (self.index, send_index))[1]

--- a/live/query.py
+++ b/live/query.py
@@ -1,9 +1,9 @@
+import os
 import inspect
 import logging
 import argparse
 import threading
 import tempfile
-import platform
 
 from live.exceptions import LiveConnectionError
 
@@ -93,9 +93,7 @@ class Query:
             live.cmd("/live/tempo", 110.0) """
 
         self.logger.debug("OSC output: %s %s", msg, args)
-        tempdir = tempfile.gettempdir()
-        tmp = tempdir + "\liveosc.log" if platform.system() == "Windows" else "/tmp/liveosc.log"
-        with open(tmp, "a") as fd:
+        with open(os.path.join(tempfile.gettempdir(), "liveosc.log"), "a") as fd:
             import datetime
             fd.write("%s %s %s\n" % (datetime.datetime.now(), msg, args))
         try:

--- a/live/query.py
+++ b/live/query.py
@@ -2,6 +2,8 @@ import inspect
 import logging
 import argparse
 import threading
+import tempfile
+import platform
 
 from live.exceptions import LiveConnectionError
 
@@ -91,7 +93,9 @@ class Query:
             live.cmd("/live/tempo", 110.0) """
 
         self.logger.debug("OSC output: %s %s", msg, args)
-        with open("/tmp/liveosc.log", "a") as fd:
+        tempdir = tempfile.gettempdir()
+        tmp = tempdir + "\liveosc.log" if platform.system() == "Windows" else "/tmp/liveosc.log"
+        with open(tmp, "a") as fd:
             import datetime
             fd.write("%s %s %s\n" % (datetime.datetime.now(), msg, args))
         try:


### PR DESCRIPTION
This PR adds support for `color_index` from the Track API: https://github.com/ideoforms/AbletonOSC#track-properties.

Thank you for your hard work! I love `pylive` :) 

Edit: also added support for Windows by getting the `tempdir` path instead of using `/tmp`