### PR TITLE
duplicate clips

### DIFF
--- a/examples/ex-clip-duplicate.py
+++ b/examples/ex-clip-duplicate.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+
+#------------------------------------------------------------------------
+# pylive: ex-clip-duplicate.py
+#
+# Demonstrates duplicating a clip to another scene.
+#
+# Requires a Live set with a clip in the first scene of the first track.
+#------------------------------------------------------------------------
+import live
+import random
+import logging
+
+logging.basicConfig(format="%(asctime)-15s %(message)s")
+logging.getLogger("live").setLevel(logging.INFO)
+
+def main():
+    #------------------------------------------------------------------------
+    # Scan the contents of the Live set, and start it playing.
+    #------------------------------------------------------------------------
+    set = live.Set(scan=True)
+    set.dump()
+    set.start_playing()
+
+    #------------------------------------------------------------------------
+    # Set 1-beat (quarter-note) quantization.
+    #------------------------------------------------------------------------
+    set.clip_trigger_quantization = 7
+
+    #------------------------------------------------------------------------
+    # Select the first track.
+    #------------------------------------------------------------------------
+    track = set.tracks[0]
+    clip = track.clips[0]
+    if clip is None:
+        raise LiveException("Please open a Live set with a clip in scene one of the first track")
+
+    if track.clips[1] is not None:
+        raise LiveException("Please clear the second clip in the first track")
+
+    clip.duplicate(1, 2)
+    duplicate_clip = set.tracks[0].clips[1]
+    clip.stop()
+    duplicate_clip.play()
+
+
+if __name__ == "__main__":
+    main()

--- a/live/classes/clip.py
+++ b/live/classes/clip.py
@@ -115,6 +115,19 @@ class Clip:
         """
         self.live.cmd("/live/clip/add/notes", (self.track.index, self.index, pitch, start_time, duration, velocity, mute))
 
+    def duplicate(self, to_track, to_clip):
+        """
+        Duplicates the current clip slot to a specified target track and clip slot.
+
+        Args:
+            to_track (int): The index of the target track where the clip should be duplicated.
+            to_clip (int): The index of the target clip slot within the target track.
+        """
+        to_track_index = to_track - 1
+        to_clip_index = to_clip - 1
+        self.live.cmd("/live/clip_slot/duplicate_clip_to", (self.track.index, self.index, to_track_index, to_clip_index))
+        self.set.scan()
+
     pitch_coarse = property(fget=make_getter("clip", "pitch_coarse"),
                             fset=make_setter("clip", "pitch_coarse"),
                             doc="Coarse pitch bend")

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -42,3 +42,7 @@ def test_clip_pitch_coarse(audio_clip):
     audio_clip.pitch_coarse = -24
     assert audio_clip.pitch_coarse == -24
     audio_clip.pitch_coarse = 0
+
+def test_clip_duplicate(clip, live_set):
+    clip.duplicate(1, 1)
+    assert len(live_set.tracks[1].clips) == 2


### PR DESCRIPTION
This change allows you to copy a clip into a different clip / track. I think I had to be on a mac to run the unit tests, so I don't know that it passes, but I did add an example that uses it.