### PR TITLE
Add Set.play_selection() handler

### DIFF
--- a/live/classes/set.py
+++ b/live/classes/set.py
@@ -631,6 +631,9 @@ class Set:
     def continue_playing(self) -> None:
         self.live.cmd("/live/song/continue_playing")
 
+    def play_selection(self) -> None:
+        self.live.cmd("/live/song/play_selection")
+
     def stop_playing(self) -> None:
         self.live.cmd("/live/song/stop_playing")
 

--- a/tests/test_set.py
+++ b/tests/test_set.py
@@ -53,6 +53,12 @@ def test_set_play(set: Set):
     set.stop_playing()
     assert set.current_song_time > 0.0
 
+    # Repeat for play_selection
+    set.play_selection()
+    time.sleep(0.1)
+    set.stop_playing()
+    assert set.current_song_time > 0.0
+
     #------------------------------------------------------------------------
     # Play without reset
     #------------------------------------------------------------------------


### PR DESCRIPTION
Adds a handler for missing [`Live.Song.play_selection`](https://docs.cycling74.com/legacy/max8/vignettes/live_object_model#:~:text=play_selection) method.

I added test assertions, however the test suite gave me an error when I attempted to run it.