### PR TITLE
Getter function for arrangement clip properties added

### DIFF
--- a/live/classes/track.py
+++ b/live/classes/track.py
@@ -238,3 +238,24 @@ class Track:
 
     def set_send(self, send_index: int, value: float):
         self.live.cmd("/live/track/set/send", (self.index, send_index, value))
+
+    #------------------------------------------------------------------------
+    # Query clip properties in Arrangement
+    #------------------------------------------------------------------------
+    """
+    All functions retrieve properties of the clips in the track in the arrangement.
+    The function always returns an array with the track_id in place 0 and the resp. property for
+    each clip in order after that.
+    The available attributes are: name, length, start_time
+    Returns: An array of track_id and the queried information of the clips in the arrangement in order.
+    Example: [track_id, name first clip, name second clip, ...]
+    """
+
+    def get_arrangement_clips_name(self):
+        return self.live.query("/live/track/get/arrangement_clips/name", (self.index,))
+
+    def get_arrangement_clips_length(self):
+        return self.live.query("/live/track/get/arrangement_clips/length", (self.index,))
+    
+    def get_arrangement_clips_start_time(self):
+        return self.live.query("/live/track/get/arrangement_clips/start_time", (self.index,))


### PR DESCRIPTION
Hi Daniel,
I got one more ;). Sorry for the spam :(. I added function to consume the /live/track/get/arrangement_clips/* AbletonOSC endpoints.

I tried to follow the naming in AbletonOSC in conjunction with the other functions in pylive.

One thing I considered is to remove the first field, since it just contains the track_id, which is the same that I just queried. However, I would argue that someone who wants to remove it can do so also afterwards and keeping it there does not hurt. It basically gives back everything that AbletonOSC returns. Everything after that is up to the consumer.
If you have any other thoughts I can also change this up.

Sorry about spamming you with these... I am just creating this stuff and hope that it is helpful to others as well... I hope you don't feel bothered by me.

Best regards,
Tobias